### PR TITLE
Added functionality to edit list items

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Listify</title>
     <link rel="stylesheet" type="text/css" href="style.css"/>
 </head>
 <body>

--- a/main.js
+++ b/main.js
@@ -50,10 +50,10 @@ function makeEditFunctional() {
     for (let i = 0; i < tasks.length; i++) {
         const edit = tasks[i].querySelector('button')
         const taskToEdit = todoItems[i]
-        edit.addEventListener('click', () => editTask(taskToEdit, i))
+        edit.addEventListener('click', () => editItem(taskToEdit, i))
     }
 }
-function editTask(task, i) {
+function editItem(task, i) {
     let newTask = prompt('Edit your task: ')    // goal for a future update: avoid prompt(), add a popup or make a new edit form visible instead
     if (newTask) {
         task = newTask

--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@ const form = document.querySelector('#todoForm')
 const input = document.querySelector('#todoInput')
 const list = document.querySelector('#todoList');
 let todoItems = []
+const editButton = `<button class="editButton">edit</button>`
 
 form.addEventListener('submit', event => {
     event.preventDefault();  //prevents page from refreshing on enter
@@ -36,9 +37,29 @@ function renderItems(todoItems) {
         li.innerHTML = `
             <input type="checkbox" class="checkbox" ${checked}> 
             ${item.name}
+            ${editButton}
         `;
         list.append(li);
     });
+    makeEditFunctional()
+}
+
+function makeEditFunctional() {
+    const tasks = Array.from(document.querySelectorAll('#todoList li'))
+
+    for (let i = 0; i < tasks.length; i++) {
+        const edit = tasks[i].querySelector('button')
+        const taskToEdit = todoItems[i]
+        edit.addEventListener('click', () => editTask(taskToEdit, i))
+    }
+}
+function editTask(task, i) {
+    let newTask = prompt('Edit your task: ')    // goal for a future update: avoid prompt(), add a popup or make a new edit form visible instead
+    if (newTask) {
+        task = newTask
+        todoItems[i].name = task
+        addToLocalStorage(todoItems)
+    }
 }
 
 function getFromLocalStorage() {

--- a/style.css
+++ b/style.css
@@ -1,5 +1,17 @@
+*,
+*:before,
+*:after {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing:    border-box;
+    box-sizing:         border-box;
+}
+html {
+    font-size: 10px;
+}
 body {
     font-family: Arial, Helvetica, sans-serif;
+    font-size: 1.5rem;
+    line-height: 1.5;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -10,4 +22,17 @@ ul {
     list-style: none;
     margin: 0;
     padding: 20px 0;
+}
+
+.editButton {
+    background: none;
+    border: 0;
+    color: #777;
+}
+.editButton:hover {
+    color: #000;
+}
+.editButton:before {
+    content: '-';
+    margin-right: 5px;
 }


### PR DESCRIPTION
### Description

I added the ability for users to edit their tasks. Clicking "edit" triggers a prompt where users can type the updated task. Resolves #5 

### Testing

Manual

### Notes

My goal for a future update is to enhance this functionality by avoiding the prompt and adding either a non-blocking pop-up, or, ideally, making a text input and submit button become visible upon clicking "edit".