### PR TITLE
added functionality to grey out a checked item and update local storage. Can uncheck as well.

### DIFF
--- a/main.js
+++ b/main.js
@@ -50,3 +50,32 @@ function getFromLocalStorage() {
   }
 getFromLocalStorage(); //initializes on page refresh
 
+
+
+
+
+
+
+
+// Event listener waiting for checked items
+list.addEventListener("change", (item) =>{ updateCheckedItem(item) })
+
+
+
+// Updated the checkbox checked status for the clicked item
+function updateCheckedItem(item){
+    const checkedItemID = Number(item.target.parentElement.getAttribute('data-key'))
+    const checkedItem = todoItems.find( item => item.id === checkedItemID)
+
+    if(item.target.checked){
+        checkedItem.completed = true
+        console.log(`${checkedItem.name} updated to completed`)
+    } else {
+        checkedItem.completed = false
+        console.log(`${checkedItem.name} updated to not completed`)
+    }
+    addToLocalStorage(todoItems)
+}
+
+
+

--- a/style.css
+++ b/style.css
@@ -11,3 +11,8 @@ ul {
     margin: 0;
     padding: 20px 0;
 }
+
+/* marking the parent li based on :has works in all browsers except Firefox right now https://caniuse.com/css-has */
+li:has( > input:checked) {
+    color: rgba(169,169,169,1);
+}


### PR DESCRIPTION
### Updates to main.js
Added event listener waiting for items to be checked.
Added updateCheckedItem() function that grabs the checked item, marks it checked in the todoItems list., then calls the existing addToLocalStorate function.
updatedCheckedItem will also allow the user to uncheck the item and it will be updated in local storage.

### Updates to style.css
Any li parent with a child with input marked as checked will be colored grey. 